### PR TITLE
Fix for BET-366 : For falco to work on CentOS, install kernel-devel module

### DIFF
--- a/images/capi/ansible/roles/common/defaults/main.yml
+++ b/images/capi/ansible/roles/common/defaults/main.yml
@@ -26,7 +26,8 @@ common_rpms:
 - python-requests
 - socat
 - yum-utils
-common_extra_rpms: []
+common_extra_rpms:
+- kernel-devel
 common_debs:
 - openssh-client
 - openssh-server


### PR DESCRIPTION
We initially had this module in os_hardening ansible role. But, having it in os_hardening caused random build failures on AWS for CentOS. From the build failures, kernel-devel module had lot of dependent modules which when installed ahead of packer was not compatible. 

So, moved kernel-devel to packer level. With the new change, CentOS builds are completing fine.