### PR TITLE
disable task which creates symlink for cloud-init

### DIFF
--- a/images/capi/ansible/roles/providers/tasks/vmware.yml
+++ b/images/capi/ansible/roles/providers/tasks/vmware.yml
@@ -70,12 +70,12 @@
 #    regexp: '(?i)lock_passwd: True'
 #    replace: 'lock_passwd: False'
 
-- name: Symlink /usr/libexec/cloud-init to /usr/lib/cloud-init
-  file:
-    src:   /usr/libexec/cloud-init
-    dest:  /usr/lib/cloud-init
-    state: link
-  when: ansible_os_family == "RedHat"
+#- name: Symlink /usr/libexec/cloud-init to /usr/lib/cloud-init
+#  file:
+#    src:   /usr/libexec/cloud-init
+#    dest:  /usr/lib/cloud-init
+#    state: link
+#  when: ansible_os_family == "RedHat"
 
 - name: Disable Hyper-V KVP protocol daemon on Ubuntu
   systemd:


### PR DESCRIPTION
Cloud-init rpm has been updated with some fixes, so image-builder failed due to below fix,
Where /var/lib/cloud-init directory is already cerate
```
* Tue Mar 05 2019 Miroslav Rezanina <mrezanin@redhat.com> - 18.2-3.el7
  - ci-cloud-init-per-don-t-use-dashes-in-sem-names.patch [bz#1664876]
  - ci-Enable-cloud-init-by-default-on-vmware.patch [bz#1623281]
  - Resolves: bz#1623281
    ([ESXi][RHEL7.6]Enable cloud-init by default on VMware)
```