### PR TITLE
Move temp-disk-swapfile task to azure redhat task file

### DIFF
--- a/images/capi/ansible/roles/providers/tasks/azure.yml
+++ b/images/capi/ansible/roles/providers/tasks/azure.yml
@@ -17,9 +17,3 @@
 
 - import_tasks: debian.yml
   when: ansible_os_family == "Debian"
-
-- name: Disable service and ensure it is masked
-  systemd:
-    name: temp-disk-swapfile
-    enabled: no
-    masked: yes

--- a/images/capi/ansible/roles/providers/tasks/redhat.yml
+++ b/images/capi/ansible/roles/providers/tasks/redhat.yml
@@ -35,3 +35,9 @@
     owner: root
     group: root
     mode: 0644
+
+- name: Disable service and ensure it is masked
+  systemd:
+    name: temp-disk-swapfile
+    enabled: no
+    masked: yes


### PR DESCRIPTION
Disabling temp-disk-swapfile is applicable only for CentOS. Moving the task to redhat.yaml which is imported only for azure provider.

Reason for this change : Ubuntu jobs are failing when this task is in azure.yaml