### PR TITLE
Set systemd cgroup driver for K8s >= 1.21

### DIFF
--- a/images/capi/ansible/roles/containerd/templates/etc/containerd/config.toml
+++ b/images/capi/ansible/roles/containerd/templates/etc/containerd/config.toml
@@ -1,0 +1,47 @@
+## template: jinja
+
+{% if ansible_os_family == "Flatcar" %}
+# persistent data location
+root = "/var/lib/containerd"
+# runtime state information
+state = "/run/docker/libcontainerd/containerd"
+# set containerd as a subreaper on linux when it is not running as PID 1
+subreaper = true
+# set containerd's OOM score
+oom_score = -999
+
+# grpc configuration
+[grpc]
+address = "/run/docker/libcontainerd/docker-containerd.sock"
+# socket uid
+uid = 0
+# socket gid
+gid = 0
+
+[plugins.linux]
+# shim binary name/path
+shim = "containerd-shim"
+# runtime binary name/path
+runtime = "runc"
+# do not use a shim when starting containers, saves on memory but
+# live restore is not supported
+no_shim = false
+# display shim logs in the containerd daemon's log output
+shim_debug = true
+
+{% else %}
+# Use config version 2 to enable new configuration fields.
+# Config file is parsed as version 1 by default.
+version = 2
+
+[plugins]
+  [plugins."io.containerd.grpc.v1.cri"]
+    sandbox_image = "{{ containerd_pause_image }}"
+  {% if kubernetes_semver is version('v1.21.0', '>=') %}
+  [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
+      SystemdCgroup = true
+  {% endif %}
+
+{% endif %}
+
+{{containerd_additional_settings | b64decode}}


### PR DESCRIPTION
When Kubernetes is 1.21.0 or greater, we want to make sure we configure
containerd to use the SystemD cgroup driver, not the default cgroupfs.