### PR TITLE
use semver according to palette

### DIFF
--- a/images/capi/ansible/roles/containerd/templates/etc/containerd/config.toml
+++ b/images/capi/ansible/roles/containerd/templates/etc/containerd/config.toml
@@ -37,7 +37,7 @@ version = 2
 [plugins]
   [plugins."io.containerd.grpc.v1.cri"]
     sandbox_image = "{{ containerd_pause_image }}"
-  {% if kubernetes_semver is version('v1.21.0', '>=') %}
+  {% if kubernetes_semver is version('1.21.0', '>=') %}
   [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
       SystemdCgroup = true
   {% endif %}


### PR DESCRIPTION
@jzhoucliqr  this change is needed as palette mold passes 

1.19.x as kubernetes_semver not v1.19.x as expected in image-builder