### PR TITLE
air gap image pull

### DIFF
--- a/images/capi/ansible/roles/containerd/tasks/main.yml
+++ b/images/capi/ansible/roles/containerd/tasks/main.yml
@@ -62,3 +62,6 @@
   file:
     path: /tmp/containerd.tar.gz
     state: absent
+
+- name: install pause image
+  command: "crictl pull {{ containerd_pause_image }}"


### PR DESCRIPTION
@jzhoucliqr  this is to ensure that pause image matching containerd version is always present.

As different `kubeadm config images pull` different pause image version. 
  