### PR TITLE
centos aws python futures rsa fix

### DIFF
--- a/images/capi/ansible/roles/providers/tasks/aws.yml
+++ b/images/capi/ansible/roles/providers/tasks/aws.yml
@@ -19,3 +19,19 @@
     packages:
       - https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz
       - awscli
+
+- name: install futures for python 2.7
+  pip:
+    name: "futures"
+  when: ansible_os_family == "RedHat"
+
+- name: uninstall default rsa
+  pip:
+    name: "rsa"
+    state: absent
+  when: ansible_os_family == "RedHat"
+
+- name: install rsa==4.0
+  pip:
+    name: rsa==4.0
+  when: ansible_os_family == "RedHat"


### PR DESCRIPTION
tried on the instance 

aws cli was failing 
```
[root@ip-10-0-3-87 boothooks]# ./part-001
+++ [2021-09-08T14:35:30+0000] aws.cluster.x-k8s.io encrypted cloud-init script ./part-001 started
+++ [2021-09-08T14:35:30+0000] secret prefix: aws.cluster.x-k8s.io/a57c7164-2a49-4258-9512-3f49b265af22
+++ [2021-09-08T14:35:30+0000] secret count: 2
+++ [2021-09-08T14:35:31+0000] getting userdata from AWS Secrets Manager
+++ [2021-09-08T14:35:31+0000] getting secret value from AWS Secrets Manager
!!! [2021-09-08T14:35:31+0000] AWS CLI reported unknown error 1 for SecretsManager::GetSecretValue
!!! [2021-09-08T14:35:31+0000] Traceback (most recent call last):  File "/bin/aws", line 27, in <module>    sys.exit(main())  File "/bin/aws", line 23, in main    return awscli.clidriver.main()  File "/usr/lib/python2.7/site-packages/awscli/clidriver.py", line 69, in main    driver = create_clidriver()  File "/usr/lib/python2.7/site-packages/awscli/clidriver.py", line 79, in create_clidriver    event_hooks=session.get_component('event_emitter'))  File "/usr/lib/python2.7/site-packages/awscli/plugin.py", line 44, in load_plugins    modules = _import_plugins(plugin_mapping)  File "/usr/lib/python2.7/site-packages/awscli/plugin.py", line 61, in _import_plugins    module = __import__(path, fromlist=[module])  File "/usr/lib/python2.7/site-packages/awscli/handlers.py", line 27, in <module>    from awscli.customizations.cloudformation import initialize as cloudformation_init  File "/usr/lib/python2.7/site-packages/awscli/customizations/cloudformation/__init__.py", line 13, in <module>    from awscli.customizations.cloudformation.package import PackageCommand  File "/usr/lib/python2.7/site-packages/awscli/customizations/cloudformation/package.py", line 26, in <module>    from awscli.customizations.s3uploader import S3Uploader  File "/usr/lib/python2.7/site-packages/awscli/customizations/s3uploader.py", line 22, in <module>    from s3transfer.manager import TransferManager  File "/usr/lib/python2.7/site-packages/s3transfer/__init__.py", line 134, in <module>    import concurrent.futuresImportError: No module named concurrent.futures
!!! [2021-09-08T14:35:31+0000] could not get secret value, deleting secret
+++ [2021-09-08T14:35:31+0000] deleting secret from AWS Secrets Manager
!!! [2021-09-08T14:35:31+0000] AWS CLI reported unknown error 1 for SecretsManager::DeleteSecret
!!! [2021-09-08T14:35:31+0000] Traceback (most recent call last):  File "/bin/aws", line 27, in <module>    sys.exit(main())  File "/bin/aws", line 23, in main    return awscli.clidriver.main()  File "/usr/lib/python2.7/site-packages/awscli/clidriver.py", line 69, in main    driver = create_clidriver()  File "/usr/lib/python2.7/site-packages/awscli/clidriver.py", line 79, in create_clidriver    event_hooks=session.get_component('event_emitter'))  File "/usr/lib/python2.7/site-packages/awscli/plugin.py", line 44, in load_plugins    modules = _import_plugins(plugin_mapping)  File "/usr/lib/python2.7/site-packages/awscli/plugin.py", line 61, in _import_plugins    module = __import__(path, fromlist=[module])  File "/usr/lib/python2.7/site-packages/awscli/handlers.py", line 27, in <module>    from awscli.customizations.cloudformation import initialize as cloudformation_init  File "/usr/lib/python2.7/site-packages/awscli/customizations/cloudformation/__init__.py", line 13, in <module>    from awscli.customizations.cloudformation.package import PackageCommand  File "/usr/lib/python2.7/site-packages/awscli/customizations/cloudformation/package.py", line 26, in <module>    from awscli.customizations.s3uploader import S3Uploader  File "/usr/lib/python2.7/site-packages/awscli/customizations/s3uploader.py", line 22, in <module>    from s3transfer.manager import TransferManager  File "/usr/lib/python2.7/site-packages/s3transfer/__init__.py", line 134, in <module>    import concurrent.futuresImportError: No module named concurrent.futures
!!! [2021-09-08T14:35:31+0000] Could not delete secret value
!!! [2021-09-08T14:35:31+0000] aws.cluster.x-k8s.io encrypted cloud-init script ./part-001 exiting with status 
```

fix tried 
```
pip install futures
pip uninstall rsa
pip install -v rsa==4.0
```

ref: https://github.com/grpc/grpc/issues/23190#issuecomment-896060770
