### PR TITLE
change centos epe rpm link

### DIFF
--- a/images/capi/ansible/roles/common/defaults/main.yml
+++ b/images/capi/ansible/roles/common/defaults/main.yml
@@ -60,7 +60,7 @@ common_photon_rpms:
 - unzip
 
 common_pinned_debs: []
-common_redhat_epel_rpm: "https://dl.fedoraproject.org/pub/epel/7/x86_64/drpms/epel-release-7-13_7-14.noarch.drpm"
+common_redhat_epel_rpm: "https://dl.fedoraproject.org/pub/epel/7/x86_64/Packages/e/epel-release-7-14.noarch.rpm"
 disable_public_repos: false
 extra_debs: ""
 extra_rpms: "kernel-devel"

--- a/images/capi/ansible/roles/common/defaults/main.yml
+++ b/images/capi/ansible/roles/common/defaults/main.yml
@@ -60,7 +60,7 @@ common_photon_rpms:
 - unzip
 
 common_pinned_debs: []
-common_redhat_epel_rpm: "https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm"
+common_redhat_epel_rpm: "https://dl.fedoraproject.org/pub/epel/7/x86_64/drpms/epel-release-7-13_7-14.noarch.drpm"
 disable_public_repos: false
 extra_debs: ""
 extra_rpms: "kernel-devel"


### PR DESCRIPTION
epel old rpm link returning 403 

<img width="1679" alt="Screenshot 2021-09-13 at 9 38 15 AM" src="https://user-images.githubusercontent.com/13624472/133023539-08b3c932-b429-4539-bf42-89a43ecdb694.png">

changed from fedora repo 
<img width="792" alt="Screenshot 2021-09-13 at 9 52 15 AM" src="https://user-images.githubusercontent.com/13624472/133023623-aced2452-2745-4512-ac89-49a75b6c8de5.png">
