### PR TITLE
[aws] pin pystache==0.5.4

### DIFF
--- a/images/capi/ansible/roles/providers/tasks/aws.yml
+++ b/images/capi/ansible/roles/providers/tasks/aws.yml
@@ -12,6 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ---
+- name: install pinned versoin of pystache==0.5.4
+  pip:
+    name: "{{ packages }}"
+  vars:
+    packages:
+      - pystache==0.5.4
+
 - name: install aws clients
   pip:
     name: "{{ packages }}"


### PR DESCRIPTION
```
  Successfully uninstalled pystache-0.5.4
root@ip-172-31-53-74:~# pip install https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz
Collecting https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz
  Using cached https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz
Collecting pystache>=0.4.0 (from aws-cfn-bootstrap==1.4)
  Using cached https://files.pythonhosted.org/packages/3f/e7/8750ba6c6101d6aa5ceeb20c013adf2c6f3554a12c71d75654b468404bfa/pystache-0.6.0.tar.gz
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-build-u3_CpZ/pystache/setup.py", line 183
        command = f"pandoc -f markdown-smart --write=rst --output={rst_temp_path} {md_path}"
                                                                                           ^
    SyntaxError: invalid syntax

    ----------------------------------------
Command "python setup.py egg_info" failed with error code 1 in /tmp/pip-build-u3_CpZ/pystache/
root@ip-172-31-53-74:~# pip install pystache==0.5.4
Collecting pystache==0.5.4
Installing collected packages: pystache
Successfully installed pystache-0.5.4
root@ip-172-31-53-74:~# pip install https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz
Collecting https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz
  Using cached https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz
Requirement already satisfied: pystache>=0.4.0 in /usr/local/lib/python2.7/dist-packages (from aws-cfn-bootstrap==1.4)
Requirement already satisfied: python-daemon<2.0,>=1.5.2 in /usr/local/lib/python2.7/dist-packages (from aws-cfn-bootstrap==1.4)
Requirement already satisfied: setuptools in /usr/lib/python2.7/dist-packages (from aws-cfn-bootstrap==1.4)
Requirement already satisfied: lockfile>=0.9 in /usr/local/lib/python2.7/dist-packages (from python-daemon<2.0,>=1.5.2->aws-cfn-bootstrap==1.4)
Building wheels for collected packages: aws-cfn-bootstrap
  Running setup.py bdist_wheel for aws-cfn-bootstrap ... done
  Stored in directory: /root/.cache/pip/wheels/65/fc/39/df56d50ab51e45aa751304953867bfab930271e5884cace44f
Successfully built aws-cfn-bootstrap
Installing collected packages: aws-cfn-bootstrap
Successfully installed aws-cfn-bootstrap-1.4
```